### PR TITLE
updated links to new repo name, added SBLAR to top line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Lending Application Register (LAR) Test Files
+# Small Business Lending Application Register (SBLAR) Test Files
 
 This repository contains test files that can be used to explore various parts of the beta for the Small Business Lending Data Filing Platform, also referred to as SBL or 1071. There are two subfolders within the small_business_lending folder: demo_files and dev_files. Their respective readmes have additional detail, but here's a high-level overview of their contents.
 
-## [demo_files](https://github.com/cfpb/LAR-test-files/tree/main/sbl/demo_files)
+## [demo_files](https://github.com/cfpb/RegTech-test-files/tree/main/sbl/demo_files)
 
 These files can be used to explore different scenarios on the beta for the Small Business Lending Data Filing Platform and to help users navigate through different steps of the platform. 
 
 
-## [dev_files](https://github.com/cfpb/LAR-test-files/tree/main/sbl/dev_files)
+## [dev_files](https://github.com/cfpb/RegTech-test-files/tree/main/sbl/dev_files)
 
 These files can be used to explore different scenarios on the beta for the Small Business Lending Data Filing Platform but more generally exist to show the structure of register files that will and will not pass the validation checks on the Small Business Lending Data Filing Platform. 
 
@@ -26,6 +26,6 @@ Once the file is opened in GitHub in the browser, click on the "Download raw fil
 
 Repeat this process for any individual test files that you would like to download. 
 
-You may also download this entire repo as a ZIP file by clicking "Download ZIP" from the "Code" menu button on the [main page](https://github.com/cfpb/LAR-test-files) of this repo:
+You may also download this entire repo as a ZIP file by clicking "Download ZIP" from the "Code" menu button on the [main page](https://github.com/cfpb/RegTech-test-files) of this repo:
 
 <img width="524" alt="a screenshot of a pointer hovering over the Download ZIP button for the repo, part of the instructions for downloading" src="https://github.com/user-attachments/assets/e37a9aab-6528-4078-a1a7-0a6d575c76db">

--- a/sbl/demo_files/README.md
+++ b/sbl/demo_files/README.md
@@ -2,7 +2,7 @@
 
 These folders contain test files that can be used by general audiences wishing to test the beta for the Small Business Lending Platform. These files are for use in the beta for the Small Business Lending Filing Platform only, validation methods are subject to change. 
 
-For developers and those wanting to test specific details or aspects of the beta for the Small Business Lending Data Filing Platform, please see the **[dev files](https://github.com/cfpb/LAR-test-files/tree/6359bc53119b29ecc4ee16ca4df59c1c17af514f/sbl/dev_files)** folder in this repo. 
+For developers and those wanting to test specific details or aspects of the beta for the Small Business Lending Data Filing Platform, please see the **[dev files](https://github.com/cfpb/RegTech-test-files/tree/6359bc53119b29ecc4ee16ca4df59c1c17af514f/sbl/dev_files)** folder in this repo. 
 
 Page sections:
 - [Filing platform overview](#filing-platform-overview)
@@ -84,6 +84,6 @@ Once the file is opened in GitHub in the browser, click on the "Download raw fil
 
 Repeat this process for any individual files that you would like to download for testing with the beta for the Small Business Lending Data Filing Platform. 
 
-You may also download this entire repo as a ZIP file by clicking "Download ZIP" from the "Code" menu button on the [main page](https://github.com/cfpb/LAR-test-files) of this repo:
+You may also download this entire repo as a ZIP file by clicking "Download ZIP" from the "Code" menu button on the [main page](https://github.com/cfpb/RegTech-test-files) of this repo:
 
 <img width="524" alt="a screenshot of a pointer hovering over the Download ZIP button for the repo, part of the instructions for downloading" src="https://github.com/user-attachments/assets/e37a9aab-6528-4078-a1a7-0a6d575c76db">


### PR DESCRIPTION
Updated the links to the new repo name (RegTech-test-files) - links weren't broken, but thought they should be accurate anyways. Also updated LAR to SBLAR in the top line. 